### PR TITLE
this push was to fix the five_combo situation...

### DIFF
--- a/cubeai/cube/moves.py
+++ b/cubeai/cube/moves.py
@@ -161,8 +161,9 @@ class Cube:
     def identify_cross_edge_type(self, face='white'):    
         _edge_count = 0
         orientation = ['green', 'red', 'blue', 'orange', 'green'] # including green second time so that list not out of index
+        orientation_adjust = ['green', 'red', 'blue', 'orange'] # including green above was a dangerous way to handle this...smh, coming back months later to find out why some three_type combo cases yielding "y".. and this is was the reason why. adding this "adjust" variable for now, but this needs to be fixed. includeing an update unit test asap to include three type for orange layer
 
-        _seven_type, _three_type, _one_type, _five_type, _top_type, _bottum_type = {}, {}, {}, {}, {}, {}
+        _seven_type, _three_type, _one_type, _top_type, _five_type, _bottum_type = {}, {}, {}, {}, {}, {}
 
         _edges = {1,3,5,7}
 
@@ -175,8 +176,8 @@ class Cube:
         # easy type, ie in the 7 slot of non-yelloow face
         if self.get_edge_count()[face] < 4:
             for i in range(4):
-                if self.cube_state[orientation[i]][3] == 'w':
-                    _three_type[orientation[i]] = [self.cube_state[orientation[i-1]][8], self.cube_state[orientation[i-1]][7]]
+                if self.cube_state[orientation_adjust[i]][3] == 'w':
+                    _three_type[orientation_adjust[i]] = [self.cube_state[orientation_adjust[i-1]][8], self.cube_state[orientation_adjust[i-1]][7]]
         
         # one move away from easy type, ie in the one/five slot of non-yellow face
         if self.get_edge_count()[face] < 4:
@@ -230,8 +231,8 @@ class Cube:
             {'_seven_type': _seven_type}, 
             {'_three_type': _three_type}, 
             {'_one_type': _one_type}, 
-            {'_five_type': _five_type},
             {'_top_type': _top_type},
+            {'_five_type': _five_type},
             {'bottum_type': _bottum_type}
         ]
         return cross_edge_types 
@@ -270,7 +271,7 @@ class Cube:
         else:
             layer_delta = (color_mapping[_combo[i][2]] - color_mapping[_combo[j][2]])
             
-        sticker_delta = (color_mapping[_combo[i][3]] - color_mapping[_combo[j][3]])
+        sticker_delta = (color_mapping[_combo[i][3]] - color_mapping[_combo[j][3]]) # an edge type for y/w edge case is not needed because sticker will not be yellow or white for this release on sticker_delta
         
         tops = ['_top_type', '_one_type']
         bottums = ['_five_type', 'bottum_type']

--- a/cubeai/test/test_state_gen.py
+++ b/cubeai/test/test_state_gen.py
@@ -172,7 +172,8 @@ def test_identify_cross_edge_type():
         ['R', 'R', 'Fp', 'Dp', 'B', 'D', 'D', 'Lp', 'Fp', 'D', 'F', 'R', 'R', 'D', 'D'],
         ['R', 'R', 'Fp', 'Dp', 'B', 'D', 'D', 'Lp', 'Fp', 'D', 'F', 'R', 'R', 'D', 'D', 'L', 'L'],
         ['R', 'R', 'Fp', 'Dp', 'B', 'D', 'D', 'Lp', 'Fp', 'D', 'F', 'R', 'R', 'D', 'D', 'L', 'L', 'Rp'],
-        ['R', 'R', 'Fp', 'Dp', 'B', 'D', 'D', 'Lp', 'Fp', 'D', 'F', 'R', 'R', 'D', 'D', 'Lp', 'Up', 'B']
+        ['R', 'R', 'Fp', 'Dp', 'B', 'D', 'D', 'Lp', 'Fp', 'D', 'F', 'R', 'R', 'D', 'D', 'Lp', 'Up', 'B'],
+        ['R', 'R', 'Fp', 'Dp', 'B', 'D', 'D', 'Lp', 'Fp', 'D', 'F', 'R', 'R', 'D', 'D', 'D', 'B', 'Rp', 'D', 'Rp', 'D', 'R', 'R']
     ]
 
     cubes = iterate_through_scrambles_for_testing(scrambles)
@@ -181,8 +182,8 @@ def test_identify_cross_edge_type():
         {'_seven_type': {'orange': ['g', 'r']}},
         {'_three_type': {'orange': ['b', 'g']}},
         {'_one_type': {'orange': ['y', 'b']}},
-        {'_five_type': {}},
         {'_top_type': {}},
+        {'_five_type': {}},
         {'bottum_type': {'white_r': ['r', 'o']}}
     ]
         
@@ -190,8 +191,8 @@ def test_identify_cross_edge_type():
         {'_seven_type': {'orange': ['g', 'r']}},
         {'_three_type': {'orange': ['b', 'g']}},
         {'_one_type': {'orange': ['y', 'b']}},
-        {'_five_type': {}},
         {'_top_type': {'yellow_r': ['r', 'o']}},
+        {'_five_type': {}},
         {'bottum_type': {}}
     ]
         
@@ -200,8 +201,8 @@ def test_identify_cross_edge_type():
         {'_seven_type': {'orange': ['g', 'b']}},
         {'_three_type': {}},
         {'_one_type': {'orange': ['y', 'g']}},
-        {'_five_type': {'orange': ['w', 'r']}},
         {'_top_type': {'yellow_r': ['r', 'o']}},
+        {'_five_type': {'orange': ['w', 'r']}},
         {'bottum_type': {}}
     ]
     
@@ -209,8 +210,17 @@ def test_identify_cross_edge_type():
         {'_seven_type': {'green': ['r', 'o'], 'orange': ['g', 'r']}},
         {'_three_type': {'blue': ['r', 'b']}},
         {'_one_type': {}},
-        {'_five_type': {}},
         {'_top_type': {'yellow_b': ['b', 'g']}},
+        {'_five_type': {}},
+        {'bottum_type': {}}
+    ]
+
+    assert cubes[4].identify_cross_edge_type() == [
+        {'_seven_type': {}},
+        {'_three_type': {'green': ['o', 'o']}},
+        {'_one_type': {}},
+        {'_top_type': {'yellow_b': ['b', 'g']}},
+        {'_five_type': {'red': ['w', 'r'], 'blue': ['w', 'b']}},
         {'bottum_type': {}}
     ]
 
@@ -222,7 +232,9 @@ def test_combo():
         ['R', 'R', 'Fp', 'Dp', 'B', 'D', 'D', 'Lp', 'Fp', 'D', 'F', 'R', 'R', 'D', 'D', 'B', 'B'],
         ['R', 'R', 'Fp', 'Dp', 'B', 'D', 'D', 'Lp', 'Fp', 'D', 'F', 'R', 'R', 'D', 'D', 'B'],
         ['R', 'R', 'Fp', 'Dp', 'B', 'D', 'D', 'Lp', 'Fp', 'D', 'F', 'R', 'R', 'D', 'D', 'F', 'F'],
-        ['R', 'R', 'Fp', 'Dp', 'B', 'D', 'D', 'Lp', 'Fp', 'D', 'F', 'R', 'R', 'D', 'D', 'Fp']
+        ['R', 'R', 'Fp', 'Dp', 'B', 'D', 'D', 'Lp', 'Fp', 'D', 'F', 'R', 'R', 'D', 'D', 'Fp'],
+        ['R', 'R', 'Fp', 'Dp', 'B', 'D', 'D', 'Lp', 'Fp', 'D', 'F', 'R', 'R', 'D', 'D', 'D', 'B', 'Rp', 'D', 'Rp', 'D', 'R', 'R']
+
     ]
 
     cubes = iterate_through_scrambles_for_testing(scrambles)
@@ -274,11 +286,20 @@ def test_combo():
         ['bottum_type', 'white_r', 'r', 'o']
         ]
 
+    assert cubes[7].combo() == [
+        ['_three_type', 'green', 'o', 'o'],
+        ['_top_type', 'yellow_b', 'b', 'g'],
+        ['_five_type', 'red', 'w', 'r'],
+        ['_five_type', 'blue', 'w', 'b']
+        ]
+    
+
+
 def test_seven_three_orientation_delta():
     many_scrambles = [
             ['R', 'R', 'Fp', 'Dp', 'B', 'D', 'D', 'Lp', 'Fp', 'D', 'F', 'R', 'R', 'D', 'D'], # seven/three/one/bottum
             ['R', 'R', 'Fp', 'Dp', 'B', 'D', 'D', 'Lp', 'Fp', 'D', 'F', 'R', 'R', 'D', 'D', 'D', 'B'], # seven/one/top/bottum
-            ['R', 'R', 'Fp', 'Dp', 'B', 'D', 'D', 'Lp', 'Fp', 'D', 'F', 'R', 'R', 'D', 'D', 'D', 'B', 'Rp', 'D'] # seven/five/top/bottum
+            ['R', 'R', 'Fp', 'Dp', 'B', 'D', 'D', 'Lp', 'Fp', 'D', 'F', 'R', 'R', 'D', 'D', 'D', 'B', 'Rp', 'D'] # seven/top/five/bottum
         ]
     
     cubes = iterate_through_scrambles_for_testing(many_scrambles)
@@ -293,14 +314,16 @@ def test_seven_three_orientation_delta():
     assert cubes[1].seven_three_orientation_delta(0, 2) == ['U', 'U']
 
     assert cubes[2].seven_three_orientation_delta(0, 3) == ['D', 'D']
-    assert cubes[2].seven_three_orientation_delta(0, 1) == ['D', 'D']
-    assert cubes[2].seven_three_orientation_delta(0, 2) == ['U', 'U']
+    assert cubes[2].seven_three_orientation_delta(0, 1) == ['U', 'U']
+    assert cubes[2].seven_three_orientation_delta(0, 2) == ['D', 'D']
 
 def test_combine_seven_three_orientation_delta():
     many_scrambles = [
             ['R', 'R', 'Fp', 'Dp', 'B', 'D', 'D', 'Lp', 'Fp', 'D', 'F', 'R', 'R', 'D', 'D'], # seven/three/one/bottum
             ['R', 'R', 'Fp', 'Dp', 'B', 'D', 'D', 'Lp', 'Fp', 'D', 'F', 'R', 'R', 'D', 'D', 'D', 'B'], # seven/one/top/bottum
-            ['R', 'R', 'Fp', 'Dp', 'B', 'D', 'D', 'Lp', 'Fp', 'D', 'F', 'R', 'R', 'D', 'D', 'D', 'B', 'Rp', 'D'] # seven/five/top/bottum
+            ['R', 'R', 'Fp', 'Dp', 'B', 'D', 'D', 'Lp', 'Fp', 'D', 'F', 'R', 'R', 'D', 'D', 'D', 'B', 'Rp', 'D'], # seven/top/five/bottum
+            ['R', 'R', 'Fp', 'Dp', 'B', 'D', 'D', 'Lp', 'Fp', 'D', 'F', 'R', 'R', 'D', 'D', 'D', 'B', 'Rp', 'D', 'Rp', 'D', 'R', 'R'] # three/top/five/five
+
         ]
     
     cubes = iterate_through_scrambles_for_testing(many_scrambles)
@@ -311,9 +334,11 @@ def test_combine_seven_three_orientation_delta():
     assert cubes[1].combine_seven_three_orientation_delta(0, 3, 1) == ['D', 'D', 'U']
     assert cubes[1].combine_seven_three_orientation_delta(0, 3, 2) == ['D', 'D', 'U', 'U']
 
-    assert cubes[2].combine_seven_three_orientation_delta(0, 3, 2) == ['D', 'D', 'U', 'U']
-    assert cubes[2].combine_seven_three_orientation_delta(0, 1, 2) == ['D', 'D', 'U', 'U']
+    assert cubes[2].combine_seven_three_orientation_delta(0, 1, 2) == ['U', 'U', 'D', 'D']
+    assert cubes[2].combine_seven_three_orientation_delta(0, 1, 3) == ['U', 'U', 'D', 'D']
 
+    assert cubes[3].combine_seven_three_orientation_delta(0, 1, 2) == ['U', 'D', 'D']
+    assert cubes[3].combine_seven_three_orientation_delta(0, 1, 3) == ['U', 'Dp']
 
 def test_seven_type_cross_solver():
     scrambles = [
@@ -323,7 +348,8 @@ def test_seven_type_cross_solver():
         ['R', 'R', 'Fp', 'Dp', 'B', 'D', 'D', 'Lp', 'Fp', 'D', 'F', 'R', 'R', 'D', 'D', 'Bp'], # seven/one/bottum/bottum
         ['R', 'R', 'Fp', 'Dp', 'B', 'D', 'D', 'Lp', 'Fp', 'D', 'F', 'R', 'R', 'D', 'D'], # seven/three/one/bottum
         ['R', 'R', 'Fp', 'Dp', 'B', 'D', 'D', 'Lp', 'Fp', 'D', 'F', 'R', 'R', 'D', 'D', 'B'], # seven/one/top/bottum
-        ['R', 'R', 'Fp', 'Dp', 'B', 'D', 'D', 'Lp', 'Fp', 'D', 'F', 'R', 'R', 'D', 'D', 'B', 'B'] # seven/seven/one/bottum
+        ['R', 'R', 'Fp', 'Dp', 'B', 'D', 'D', 'Lp', 'Fp', 'D', 'F', 'R', 'R', 'D', 'D', 'B', 'B'], # seven/seven/one/bottum
+        ['R', 'R', 'Fp', 'Dp', 'B', 'D', 'D', 'Lp', 'Fp', 'D', 'F', 'R', 'R', 'D', 'D', 'D', 'B', 'Rp', 'D'] # seven/top/five/bottum
     ]
 
     cubes = iterate_through_scrambles_for_testing(scrambles)
@@ -335,6 +361,8 @@ def test_seven_type_cross_solver():
     assert cubes[4].seven_type_cross_solver() == [['U', 'Dp', 'F']]
     assert cubes[5].seven_type_cross_solver() == [['U', 'Dp', 'F'], ['U', 'U', 'Dp', 'F']]
     assert cubes[6].seven_type_cross_solver() == [['Up', 'I', 'B'], ['U', 'Dp', 'F']]
+    assert cubes[7].seven_type_cross_solver() == [['U', 'U', 'D', 'D', 'F'], ['U', 'U', 'D', 'D', 'F']]
+
 
 
 def test_three_type_cross_solver():
@@ -345,7 +373,8 @@ def test_three_type_cross_solver():
         ['R', 'R', 'Fp', 'Dp', 'B', 'D', 'D', 'Lp', 'Fp', 'D', 'F', 'R', 'R', 'D', 'D', 'U', 'Fp', 'L', 'F', 'Lp'], # seven/seven/three/bottum
         ['Fp', 'R', 'Fp', 'Bp', 'L', 'Bp'], # one/one/one/one
         ['Fp', 'R', 'Fp', 'Bp', 'L', 'Bp', 'Fp', 'Rp', 'Bp', 'Fp', 'Lp', 'F', 'F', 'F', 'B', 'B'], # three/three/three/three
-        ['D', 'Fp', 'Lp', 'B', 'D', 'D', 'L', 'B', 'Lp', 'Bp'] # seven/seven/seven/three
+        ['D', 'Fp', 'Lp', 'B', 'D', 'D', 'L', 'B', 'Lp', 'Bp'], # seven/seven/seven/three
+        ['R', 'R', 'Fp', 'Dp', 'B', 'D', 'D', 'Lp', 'Fp', 'D', 'F', 'R', 'R', 'D', 'D', 'D', 'B', 'Rp', 'D', 'Rp', 'D', 'R', 'R'] # three/top/five/five
     ]
 
     cubes = iterate_through_scrambles_for_testing(scrambles)
@@ -357,3 +386,6 @@ def test_three_type_cross_solver():
     assert cubes[4].three_type_cross_solver() == None
     assert cubes[5].three_type_cross_solver() == [['I', 'Rp'], ['I', 'Fp'], ['I', 'Lp'], ['I', 'Bp']]
     assert cubes[6].three_type_cross_solver() == [['I', 'Lp'], ['I', 'Bp']]
+    assert cubes[7].three_type_cross_solver() == [['U', 'D', 'D', 'Rp'], ['U', 'Dp', 'Rp']]
+
+


### PR DESCRIPTION
at first, i was just rearranging the order of combo as i realized the five type was not set to be near the end as it should have. while doing this, one of the cases i was testing happened to not be working. i thought there was an issue with orientation delta, but it turns out that the identify_cross_edge_type function had a major bug (it was identifying wrong sticker for edges due to adding an extra green to fix the loop... it is now patched, however this orientation_adjust variable in the function should be adjusted in a later release). after fixing, i added a unit test for the three_type with green/orange layer incident. 